### PR TITLE
Add GitHub Pages deployment workflow and configure base URL in chat-ui

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,77 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Deploy to GitHub Pages
+
+on:
+#  push:
+#    branches: [ "main" ]
+#    paths:
+#      - 'chat-ui/**'
+#      - 'docs/**'
+#  pull_request:
+#    branches: [ "main" ]
+#    paths:
+#      - 'chat-ui/**'
+#      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: chat-ui
+
+    strategy:
+      matrix:
+        node-version: [24.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+        cache-dependency-path: 'chat-ui/package-lock.json'
+    - run: npm ci
+    - name: Build with base URL for GitHub Pages
+      run: npm run build
+      env:
+        BASE_URL: /koog-spring-boot-assistant/
+    - run: npm run check
+    - name: Prepare deployment directory
+      run: |
+        mkdir -p ../deploy
+        cp -r dist/* ../deploy/
+        cp -r ../docs/*.yaml ../deploy/docs/
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v4
+      # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      with:
+        path: 'deploy'
+
+  deploy:
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/chat-ui/package.json
+++ b/chat-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:gh-pages": "BASE_URL=/koog-spring-boot-assistant/ vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
   },

--- a/chat-ui/vite.config.ts
+++ b/chat-ui/vite.config.ts
@@ -3,6 +3,7 @@ import {svelte} from '@sveltejs/vite-plugin-svelte'
 
 // https://vite.dev/config/
 export default defineConfig({
+    base: process.env.BASE_URL || '/',
     plugins: [svelte()],
     server: {
         port: 3000,


### PR DESCRIPTION
- Introduced `.github/workflows/deploy-pages.yml` to enable GitHub Pages deployment.
- Added `build:gh-pages` script to `package.json` for building with a custom base URL.
- Updated `vite.config.ts` with environment-based base URL configuration.